### PR TITLE
refactor: Wrap `JSON.parse` in a try-catch when parsing the query

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -29,7 +29,9 @@ app.set('query parser', function (str) {
   for (const key in query) {
     const value = query[key];
     if (typeof value === 'string' && value.startsWith('"') && value.endsWith('"')) {
-      query[key] = JSON.parse(value);
+      try {
+        query[key] = JSON.parse(value);
+      } catch {}
     }
   }
 


### PR DESCRIPTION
Guard against malformed json strings just to be safe